### PR TITLE
Remove publish job and axo hosting

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -13,14 +13,12 @@ installers = ["shell", "powershell", "npm", "homebrew"]
 tap = "axodotdev/homebrew-tap"
 # A namespace to use when publishing this package to the npm registry
 npm-scope = "@axodotdev"
-# Publish jobs to run in CI
-publish-jobs = ["homebrew", "npm", "./publish-crates"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Where to host releases
-hosting = ["axodotdev", "github"]
+hosting = ["github"]
 # Whether to install an updater program
 install-updater = false
 # Whether to enable GitHub Attestations


### PR DESCRIPTION
We don't plan on publishing this, remove the jobs. Also remove `axodotdev` hosting.