### PR TITLE
Fix tests relying on dist package config

### DIFF
--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -31,14 +31,6 @@ stdout:
           "artifact_download_path": "/oxidecomputer/cargo-dist/releases/download/dist-schema-v1.0.0-FAKEVERSION",
           "owner": "oxidecomputer",
           "repo": "cargo-dist"
-        },
-        "axodotdev": {
-          "package": "dist-schema",
-          "public_id": "fake-id-do-not-upload",
-          "set_download_url": "https://fake.axo.dev/faker/dist-schema/fake-id-do-not-upload",
-          "upload_url": null,
-          "release_url": null,
-          "announce_url": null
         }
       }
     }
@@ -64,6 +56,3 @@ stdout:
 }
 
 stderr:
-INFO: You've enabled Axo Releases, which is currently in Closed Beta.
-If you haven't yet signed up, please join our discord
-(https://discord.gg/ECnWuUUXQk) or message hello@axo.dev to get started!

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -31,14 +31,6 @@ stdout:
           "artifact_download_path": "/oxidecomputer/cargo-dist/releases/download/dist-schema/v1.0.0-FAKEVERSION",
           "owner": "oxidecomputer",
           "repo": "cargo-dist"
-        },
-        "axodotdev": {
-          "package": "dist-schema",
-          "public_id": "fake-id-do-not-upload",
-          "set_download_url": "https://fake.axo.dev/faker/dist-schema/fake-id-do-not-upload",
-          "upload_url": null,
-          "release_url": null,
-          "announce_url": null
         }
       }
     }
@@ -64,6 +56,3 @@ stdout:
 }
 
 stderr:
-INFO: You've enabled Axo Releases, which is currently in Closed Beta.
-If you haven't yet signed up, please join our discord
-(https://discord.gg/ECnWuUUXQk) or message hello@axo.dev to get started!

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -55,14 +55,6 @@ stdout:
           "artifact_download_path": "/oxidecomputer/cargo-dist/releases/download/v1.0.0-FAKEVERSION",
           "owner": "oxidecomputer",
           "repo": "cargo-dist"
-        },
-        "axodotdev": {
-          "package": "dist",
-          "public_id": "fake-id-do-not-upload",
-          "set_download_url": "https://fake.axo.dev/faker/dist/fake-id-do-not-upload",
-          "upload_url": null,
-          "release_url": null,
-          "announce_url": null
         }
       }
     }
@@ -205,7 +197,7 @@ stdout:
         "x86_64-pc-windows-gnu",
         "x86_64-pc-windows-msvc"
       ],
-      "install_hint": "powershell -ExecutionPolicy Bypass -c \"irm https://fake.axo.dev/faker/dist/fake-id-do-not-upload/dist-installer.ps1 | iex\"",
+      "install_hint": "powershell -ExecutionPolicy Bypass -c \"irm https://github.com/oxidecomputer/cargo-dist/releases/download/v1.0.0-FAKEVERSION/dist-installer.ps1 | iex\"",
       "description": "Install prebuilt binaries via powershell script"
     },
     "dist-installer.sh": {
@@ -222,7 +214,7 @@ stdout:
         "x86_64-unknown-linux-musl-dynamic",
         "x86_64-unknown-linux-musl-static"
       ],
-      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://fake.axo.dev/faker/dist/fake-id-do-not-upload/dist-installer.sh | sh",
+      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oxidecomputer/cargo-dist/releases/download/v1.0.0-FAKEVERSION/dist-installer.sh | sh",
       "description": "Install prebuilt binaries via shell script"
     },
     "dist-manifest-schema.json": {
@@ -636,6 +628,3 @@ stdout:
 }
 
 stderr:
-INFO: You've enabled Axo Releases, which is currently in Closed Beta.
-If you haven't yet signed up, please join our discord
-(https://discord.gg/ECnWuUUXQk) or message hello@axo.dev to get started!


### PR DESCRIPTION
With 15f6f2dc (Remove publish job and axo hosting, 2025-06-13) we removed a few unneeded `dist` config options, breaking a few tests that rely on our own config settings.

Update the impacted snapshots.