### PR TITLE
Fix remainder of ubuntu-20.04 jobs

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -31,11 +31,13 @@ build = ["cargo", "run", "--release", "--", "dist", "manifest-schema", "--output
 
 [dist.github-custom-runners]
 global = "ubuntu-latest"
+x86_64-unknown-linux-gnu = "ubuntu-latest"
+x86_64-unknown-linux-musl = "ubuntu-latest"
 
-[dist.github-custom-runners.aarch64-unknown-linux-gnu.container]
-image = "quay.io/pypa/manylinux_2_28_x86_64"
-host = "x86_64-unknown-linux-musl"
+[dist.github-custom-runners.aarch64-unknown-linux-gnu]
+runner = "ubuntu-latest"
+container = { image = "quay.io/pypa/manylinux_2_28_x86_64", host = "x86_64-unknown-linux-musl" }
 
-[dist.github-custom-runners.aarch64-unknown-linux-musl.container]
-image = "quay.io/pypa/manylinux_2_28_x86_64"
-host = "x86_64-unknown-linux-musl"
+[dist.github-custom-runners.aarch64-unknown-linux-musl]
+runner = "ubuntu-latest"
+container = { image = "quay.io/pypa/manylinux_2_28_x86_64", host = "x86_64-unknown-linux-musl" }


### PR DESCRIPTION
We had a few other release CI jobs that were defaulting to ubuntu-20.04. Update the default runner for all Linux triples to use ubuntu-latest.