### PR TITLE
Enable macOS binary signing

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,6 +21,8 @@ install-updater = false
 github-attestations = true
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
+# Sign macOS binaries
+macos-sign = true
 
 [[dist.extra-artifacts]]
 artifacts = ["dist-manifest-schema.json"]


### PR DESCRIPTION
Turn on the existing macOS binary signature feature. This notably does not set the hardened runtime or timestamp options on `codesign`, which are needed for notarization to succeed. We'll cover that in a subsequent PR.