### PR TITLE
Fix macOS codesigning not being enabled

### DIFF
--- a/cargo-dist/src/config/v0_to_v1.rs
+++ b/cargo-dist/src/config/v0_to_v1.rs
@@ -136,6 +136,7 @@ impl DistMetadata {
         let needs_build_layer = cargo_layer.is_some()
             || system_dependencies.is_some()
             || ssldotcom_windows_sign.is_some()
+            || macos_sign.is_some()
             || msvc_crt_static.is_some()
             || min_glibc_version.is_some()
             || omnibor.is_some();

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -622,6 +622,44 @@ install-location = "/opt/axolotlsay"
 }
 
 #[test]
+fn axolotlsay_macos_sign() -> Result<(), miette::Report> {
+    let test_name = _function_name!();
+    AXOLOTLSAY.run_test(|ctx| {
+        let dist_version = ctx.tools.cargo_dist.version().unwrap();
+        ctx.patch_cargo_toml(format!(r#"
+[workspace.metadata.dist]
+cargo-dist-version = "{dist_version}"
+installers = ["shell", "powershell", "msi", "pkg"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+ci = ["github"]
+macos-sign = true
+unix-archive = ".tar.gz"
+windows-archive = ".tar.gz"
+
+[package.metadata.wix]
+upgrade-guid = "B36177BE-EA4D-44FB-B05C-EDDABDAA95CA"
+path-guid = "BFD25009-65A4-4D1E-97F1-0030465D90D6"
+
+[package.metadata.dist.mac-pkg-config]
+identifier = "dev.axo.axolotsay"
+install-location = "/opt/axolotlsay"
+
+"#
+        ))?;
+
+        // Run generate to make sure stuff is up to date before running other commands
+        let ci_result = ctx.cargo_dist_generate(test_name)?;
+        let ci_snap = ci_result.check_all()?;
+        // Do usual build+plan checks
+        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
+        let main_snap = main_result.check_all(&ctx, ".cargo/bin/")?;
+        // snapshot all
+        main_snap.join(ci_snap).snap();
+        Ok(())
+    })
+}
+
+#[test]
 fn axolotlsay_user_plan_job() -> Result<(), miette::Report> {
     let test_name = _function_name!();
     AXOLOTLSAY.run_test(|ctx| {

--- a/cargo-dist/tests/snapshots/axolotlsay_macos_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_macos_sign.snap
@@ -1,0 +1,2830 @@
+---
+source: cargo-dist/tests/gallery/dist/snapshot.rs
+expression: self.payload
+---
+================ axolotlsay-installer.sh ================
+#!/bin/sh
+# shellcheck shell=dash
+#
+# Licensed under the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+if [ "$KSH_VERSION" = 'Version JM 93t+ 2010-03-05' ]; then
+    # The version of ksh93 that ships with many illumos systems does not
+    # support the "local" extension.  Print a message rather than fail in
+    # subtle ways later on:
+    echo 'this installer does not work with this ksh93 version; please try bash!' >&2
+    exit 1
+fi
+
+set -u
+
+APP_NAME="axolotlsay"
+APP_VERSION="0.2.2"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
+PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
+PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+RECEIPT_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/axolotlsay"
+
+usage() {
+    # print help (this cat/EOF stuff is a "heredoc" string)
+    cat <<EOF
+axolotlsay-installer.sh
+
+The installer for axolotlsay 0.2.2
+
+This script detects what platform you're on and fetches an appropriate archive from
+https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2
+then unpacks the binaries and installs them to
+
+    \$CARGO_HOME/bin (or \$HOME/.cargo/bin)
+
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
+
+USAGE:
+    axolotlsay-installer.sh [OPTIONS]
+
+OPTIONS:
+    -v, --verbose
+            Enable verbose output
+
+    -q, --quiet
+            Disable progress output
+
+        --no-modify-path
+            Don't configure the PATH environment variable
+
+    -h, --help
+            Print help information
+EOF
+}
+
+download_binary_and_run_installer() {
+    downloader --check
+    need_cmd uname
+    need_cmd mktemp
+    need_cmd chmod
+    need_cmd mkdir
+    need_cmd rm
+    need_cmd tar
+    need_cmd grep
+    need_cmd cat
+
+    for arg in "$@"; do
+        case "$arg" in
+            --help)
+                usage
+                exit 0
+                ;;
+            --quiet)
+                PRINT_QUIET=1
+                ;;
+            --verbose)
+                PRINT_VERBOSE=1
+                ;;
+            --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+                NO_MODIFY_PATH=1
+                ;;
+            *)
+                OPTIND=1
+                if [ "${arg%%--*}" = "" ]; then
+                    err "unknown option $arg"
+                fi
+                while getopts :hvq sub_arg "$arg"; do
+                    case "$sub_arg" in
+                        h)
+                            usage
+                            exit 0
+                            ;;
+                        v)
+                            # user wants to skip the prompt --
+                            # we don't need /dev/tty
+                            PRINT_VERBOSE=1
+                            ;;
+                        q)
+                            # user wants to skip the prompt --
+                            # we don't need /dev/tty
+                            PRINT_QUIET=1
+                            ;;
+                        *)
+                            err "unknown option -$OPTARG"
+                            ;;
+                        esac
+                done
+                ;;
+        esac
+    done
+
+    get_architecture || return 1
+    local _true_arch="$RETVAL"
+    assert_nz "$_true_arch" "arch"
+    local _cur_arch="$_true_arch"
+
+
+    # look up what archives support this platform
+    local _artifact_name
+    _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
+    local _bins
+    local _zip_ext
+    local _arch
+    local _checksum_style
+    local _checksum_value
+
+    # destructure selected archive info into locals
+    case "$_artifact_name" in 
+        "axolotlsay-aarch64-apple-darwin.tar.gz")
+            _arch="aarch64-apple-darwin"
+            _zip_ext=".tar.gz"
+            _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
+            _updater_name=""
+            _updater_bin=""
+            ;;
+        "axolotlsay-x86_64-apple-darwin.tar.gz")
+            _arch="x86_64-apple-darwin"
+            _zip_ext=".tar.gz"
+            _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
+            _updater_name=""
+            _updater_bin=""
+            ;;
+        "axolotlsay-x86_64-pc-windows-msvc.tar.gz")
+            _arch="x86_64-pc-windows-msvc"
+            _zip_ext=".tar.gz"
+            _bins="axolotlsay.exe"
+            _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
+            _updater_name=""
+            _updater_bin=""
+            ;;
+        "axolotlsay-x86_64-unknown-linux-gnu.tar.gz")
+            _arch="x86_64-unknown-linux-gnu"
+            _zip_ext=".tar.gz"
+            _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
+            _updater_name=""
+            _updater_bin=""
+            ;;
+        *)
+            err "internal installer error: selected download $_artifact_name doesn't exist!?"
+            ;;
+    esac
+
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
+
+    # download the archive
+    local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
+    local _dir
+    _dir="$(ensure mktemp -d)" || return 1
+    local _file="$_dir/input$_zip_ext"
+
+    say "downloading $APP_NAME $APP_VERSION ${_arch}" 1>&2
+    say_verbose "  from $_url" 1>&2
+    say_verbose "  to $_file" 1>&2
+
+    ensure mkdir -p "$_dir"
+
+    if ! downloader "$_url" "$_file"; then
+      say "failed to download $_url"
+      say "this may be a standard network error, but it may also indicate"
+      say "that $APP_NAME's release process is not working. When in doubt"
+      say "please feel free to open an issue!"
+      exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
+    fi
+
+    # ...and then the updater, if it exists
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
+        local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
+        # This renames the artifact while doing the download, removing the
+        # target triple and leaving just the appname-update format
+        local _updater_file="$_dir/$APP_NAME-update"
+
+        if ! downloader "$_updater_url" "$_updater_file"; then
+          say "failed to download $_updater_url"
+          say "this may be a standard network error, but it may also indicate"
+          say "that $APP_NAME's release process is not working. When in doubt"
+          say "please feel free to open an issue!"
+          exit 1
+        fi
+
+        # Add the updater to the list of binaries to install
+        _bins="$_bins $APP_NAME-update"
+    fi
+
+    # unpack the archive
+    case "$_zip_ext" in
+        ".zip")
+            ensure unzip -q "$_file" -d "$_dir"
+            ;;
+
+        ".tar."*)
+            ensure tar xf "$_file" --strip-components 1 -C "$_dir"
+            ;;
+        *)
+            err "unknown archive format: $_zip_ext"
+            ;;
+    esac
+
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
+    local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
+
+    ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
+
+    return "$_retval"
+}
+
+# Replaces $HOME with the variable name for display to the user,
+# only if $HOME is defined.
+replace_home() {
+    local _str="$1"
+
+    if [ -n "${HOME:-}" ]; then
+        echo "$_str" | sed "s,$HOME,\$HOME,"
+    else
+        echo "$_str"
+    fi
+}
+
+json_binary_aliases() {
+    local _arch="$1"
+
+    case "$_arch" in 
+    "aarch64-apple-darwin")
+        echo '{}'
+        ;;
+    "x86_64-apple-darwin")
+        echo '{}'
+        ;;
+    "x86_64-pc-windows-gnu")
+        echo '{}'
+        ;;
+    "x86_64-unknown-linux-gnu")
+        echo '{}'
+        ;;
+    *)
+        echo '{}'
+        ;;
+    esac
+}
+
+aliases_for_binary() {
+    local _bin="$1"
+    local _arch="$2"
+
+    case "$_arch" in 
+    "aarch64-apple-darwin")
+        case "$_bin" in
+        *)
+            echo ""
+            ;;
+        esac
+        ;;
+    "x86_64-apple-darwin")
+        case "$_bin" in
+        *)
+            echo ""
+            ;;
+        esac
+        ;;
+    "x86_64-pc-windows-gnu")
+        case "$_bin" in
+        *)
+            echo ""
+            ;;
+        esac
+        ;;
+    "x86_64-unknown-linux-gnu")
+        case "$_bin" in
+        *)
+            echo ""
+            ;;
+        esac
+        ;;
+    *)
+        echo ""
+        ;;
+    esac
+}
+
+select_archive_for_arch() {
+    local _true_arch="$1"
+    local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
+    case "$_true_arch" in 
+        "aarch64-apple-darwin")
+            _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
+            if [ -n "$_archive" ]; then
+                echo "$_archive"
+                return 0
+            fi
+            _archive="axolotlsay-x86_64-apple-darwin.tar.gz"
+            if [ -n "$_archive" ]; then
+                echo "$_archive"
+                return 0
+            fi
+            ;;
+        "aarch64-pc-windows-msvc")
+            _archive="axolotlsay-x86_64-pc-windows-msvc.tar.gz"
+            if [ -n "$_archive" ]; then
+                echo "$_archive"
+                return 0
+            fi
+            ;;
+        "x86_64-apple-darwin")
+            _archive="axolotlsay-x86_64-apple-darwin.tar.gz"
+            if [ -n "$_archive" ]; then
+                echo "$_archive"
+                return 0
+            fi
+            ;;
+        "x86_64-pc-windows-gnu")
+            _archive="axolotlsay-x86_64-pc-windows-msvc.tar.gz"
+            if [ -n "$_archive" ]; then
+                echo "$_archive"
+                return 0
+            fi
+            ;;
+        "x86_64-pc-windows-msvc")
+            _archive="axolotlsay-x86_64-pc-windows-msvc.tar.gz"
+            if [ -n "$_archive" ]; then
+                echo "$_archive"
+                return 0
+            fi
+            ;;
+        "x86_64-unknown-linux-gnu")
+            _archive="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
+            if ! check_glibc "2" "35"; then
+                _archive=""
+            fi
+            if [ -n "$_archive" ]; then
+                echo "$_archive"
+                return 0
+            fi
+            ;;
+        *)
+            err "there isn't a download for your platform $_true_arch"
+            ;;
+    esac
+    err "no compatible downloads were found for your platform $_true_arch"
+}
+
+check_glibc() {
+    local _min_glibc_major="$1"
+    local _min_glibc_series="$2"
+
+    # Parsing version out from line 1 like:
+    # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+    _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
+
+    if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = "$_min_glibc_major" ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge "$_min_glibc_series" ]; then
+        return 0
+    else
+        say "System glibc version (\`${_local_glibc}') is too old; checking alternatives" >&2
+        return 1
+    fi
+}
+
+# See discussion of late-bound vs early-bound for why we use single-quotes with env vars
+# shellcheck disable=SC2016
+install() {
+    # This code needs to both compute certain paths for itself to write to, and
+    # also write them to shell/rc files so that they can look them up to e.g.
+    # add them to PATH. This requires an active distinction between paths
+    # and expressions that can compute them.
+    #
+    # The distinction lies in when we want env-vars to be evaluated. For instance
+    # if we determine that we want to install to $HOME/.myapp, which do we add
+    # to e.g. $HOME/.profile:
+    #
+    # * early-bound: export PATH="/home/myuser/.myapp:$PATH"
+    # * late-bound:  export PATH="$HOME/.myapp:$PATH"
+    #
+    # In this case most people would prefer the late-bound version, but in other
+    # cases the early-bound version might be a better idea. In particular when using
+    # other env-vars than $HOME, they are more likely to be only set temporarily
+    # for the duration of this install script, so it's more advisable to erase their
+    # existence with early-bounding.
+    #
+    # This distinction is handled by "double-quotes" (early) vs 'single-quotes' (late).
+    #
+    # However if we detect that "$SOME_VAR/..." is a subdir of $HOME, we try to rewrite
+    # it to be '$HOME/...' to get the best of both worlds.
+    #
+    # This script has a few different variants, the most complex one being the
+    # CARGO_HOME version which attempts to install things to Cargo's bin dir,
+    # potentially setting up a minimal version if the user hasn't ever installed Cargo.
+    #
+    # In this case we need to:
+    #
+    # * Install to $HOME/.cargo/bin/
+    # * Create a shell script at $HOME/.cargo/env that:
+    #   * Checks if $HOME/.cargo/bin/ is on PATH
+    #   * and if not prepends it to PATH
+    # * Edits $HOME/.profile to run $HOME/.cargo/env (if the line doesn't exist)
+    #
+    # To do this we need these 4 values:
+
+    # The actual path we're going to install to
+    local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
+    # The install prefix we write to the receipt.
+    # For organized install methods like CargoHome, which have
+    # subdirectories, this is the root without `/bin`. For other
+    # methods, this is the same as `_install_dir`.
+    local _receipt_install_dir
+    # Path to the an shell script that adds install_dir to PATH
+    local _env_script_path
+    # Potentially-late-bound version of install_dir to write env_script
+    local _install_dir_expr
+    # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
+    local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _install_layout="cargo-home"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_layout="cargo-home"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _install_layout="flat"
+    fi
+
+    # Check if the install layout should be changed from `flat` to `cargo-home`
+    # for backwards compatible updates of applications that switched layouts.
+    if [ -n "${_force_install_dir:-}" ]; then
+        if [ "$_install_layout" = "flat" ]; then
+            # If the install directory is targeting the Cargo home directory, then
+            # we assume this application was previously installed that layout
+            if [ "$_force_install_dir" = "${CARGO_HOME:-${HOME:-}/.cargo}" ]; then
+                _install_layout="cargo-home"
+            fi
+        fi
+     fi
+
+    # Before actually consulting the configured install strategy, see
+    # if we're overriding it.
+    if [ -n "${_force_install_dir:-}" ]; then
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
+    fi
+    if [ -z "${_install_dir:-}" ]; then
+        _install_layout="cargo-home"
+        # first try $CARGO_HOME, then fallback to $HOME/.cargo
+        if [ -n "${CARGO_HOME:-}" ]; then
+            _receipt_install_dir="$CARGO_HOME"
+            _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
+            _env_script_path="$CARGO_HOME/env"
+            # Initially make this early-bound to erase the potentially-temporary env-var
+            _install_dir_expr="$_install_dir"
+            _env_script_path_expr="$_env_script_path"
+            # If CARGO_HOME was set but it ended up being the default $HOME-based path,
+            # then keep things late-bound. Otherwise bake the value for safety.
+            # This is what rustup does, and accurately reproducing it is useful.
+            if [ -n "${HOME:-}" ]; then
+                if [ "$HOME/.cargo/bin" = "$_install_dir" ]; then
+                    _install_dir_expr='$HOME/.cargo/bin'
+                    _env_script_path_expr='$HOME/.cargo/env'
+                fi
+            fi
+        elif [ -n "${HOME:-}" ]; then
+            _receipt_install_dir="$HOME/.cargo"
+            _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
+            _env_script_path="$HOME/.cargo/env"
+            _install_dir_expr='$HOME/.cargo/bin'
+            _env_script_path_expr='$HOME/.cargo/env'
+        fi
+    fi
+
+    if [ -z "$_install_dir_expr" ]; then
+        err "could not find a valid path to install to!"
+    fi
+
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    # Also replace the aliases with the arch-specific one
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
+    if [ "$NO_MODIFY_PATH" = "1" ]; then
+        RECEIPT=$(echo "$RECEIPT" | sed "s'\"modify_path\":true'\"modify_path\":false'")
+    fi
+
+    say "installing to $_install_dir"
+    ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
+
+    # copy all the binaries to the install dir
+    local _src_dir="$1"
+    local _bins="$2"
+    local _libs="$3"
+    local _staticlibs="$4"
+    local _arch="$5"
+    for _bin_name in $_bins; do
+        local _bin="$_src_dir/$_bin_name"
+        ensure mv "$_bin" "$_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_install_dir/$_bin_name"
+        for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+        done
+        say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+
+    say "everything's installed!"
+
+    # Avoid modifying the users PATH if they are managing their PATH manually
+    case :$PATH:
+      in *:$_install_dir:*) NO_MODIFY_PATH=1 ;;
+         *) ;;
+    esac
+
+    if [ "0" = "$NO_MODIFY_PATH" ]; then
+        add_install_dir_to_ci_path "$_install_dir"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
+        exit1=$?
+        shotgun_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile .bashrc .bash_profile .bash_login" "sh"
+        exit2=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
+        exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
+        fi
+    fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+    local _shadow
+
+    for _bin_name in $_bins; do
+        _shadow="$(command -v "$_bin_name")"
+        if [ -n "$_shadow" ] && [ "$_shadow" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
+}
+
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "${ZDOTDIR:-}" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
+add_install_dir_to_ci_path() {
+    # Attempt to do CI-specific rituals to get the install-dir on PATH faster
+    local _install_dir="$1"
+
+    # If GITHUB_PATH is present, then write install_dir to the file it refs.
+    # After each GitHub Action, the contents will be added to PATH.
+    # So if you put a curl | sh for this script in its own "run" step,
+    # the next step will have this dir on PATH.
+    #
+    # Note that GITHUB_PATH will not resolve any variables, so we in fact
+    # want to write install_dir and not install_dir_expr
+    if [ -n "${GITHUB_PATH:-}" ]; then
+        ensure echo "$_install_dir" >> "$GITHUB_PATH"
+    fi
+}
+
+add_install_dir_to_path() {
+    # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
+    #
+    # We do this slightly indirectly by creating an "env" shell script which checks if install_dir
+    # is on $PATH already, and prepends it if not. The actual line we then add to rcfiles
+    # is to just source that script. This allows us to blast it into lots of different rcfiles and
+    # have it run multiple times without causing problems. It's also specifically compatible
+    # with the system rustup uses, so that we don't conflict with it.
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+    local _shell="$5"
+
+    if [ -n "${HOME:-}" ]; then
+        local _target
+        local _home
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
+        fi
+
+        # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
+        # This apparently comes up a lot on freebsd. It's easy enough to always add
+        # the more robust line to rcfiles, but when telling the user to apply the change
+        # to their current shell ". x" is pretty easy to misread/miscopy, so we use the
+        # prettier "source x" line there. Hopefully people with Weird Shells are aware
+        # this is a thing and know to tweak it (or just restart their shell).
+        local _robust_line=". \"$_env_script_path_expr\""
+        local _pretty_line="source \"$_env_script_path_expr\""
+
+        # Add the env script if it doesn't already exist
+        if [ ! -f "$_env_script_path" ]; then
+            say_verbose "creating $_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
+        else
+            say_verbose "$_env_script_path already exists"
+        fi
+
+        # Check if the line is already in the rcfile
+        # grep: 0 if matched, 1 if no match, and 2 if an error occurred
+        #
+        # Ideally we could use quiet grep (-q), but that makes "match" and "error"
+        # have the same behaviour, when we want "no match" and "error" to be the same
+        # (on error we want to create the file, which >> conveniently does)
+        #
+        # We search for both kinds of line here just to do the right thing in more cases.
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
+        then
+            # If the script now exists, add the line to source it to the rcfile
+            # (This will also create the rcfile if it doesn't exist)
+            if [ -f "$_env_script_path" ]; then
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
+                # prepend an extra newline in case the user's file is missing a trailing one
+                ensure echo "" >> "$_target"
+                ensure echo "$_line" >> "$_target"
+                return 1
+            fi
+        else
+            say_verbose "$_install_dir already on PATH"
+        fi
+    fi
+}
+
+shotgun_install_dir_to_path() {
+    # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
+    # (Shotgun edition - write to all provided files that exist rather than just the first)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+    local _shell="$5"
+
+    if [ -n "${HOME:-}" ]; then
+        local _found=false
+        local _home
+
+        for _rcfile_relative in $_rcfiles; do
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile_abs="$_home/$_rcfile_relative"
+
+            if [ -f "$_rcfile_abs" ]; then
+                _found=true
+                add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" "$_rcfile_relative" "$_shell"
+            fi
+        done
+
+        # Fall through to previous "create + write to first file in list" behavior
+	    if [ "$_found" = false ]; then
+            add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" "$_rcfiles" "$_shell"
+        fi
+    fi
+}
+
+write_env_script_sh() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+#!/bin/sh
+# add binaries to PATH if they aren't added yet
+# affix colons on either side of \$PATH to simplify matching
+case ":\${PATH}:" in
+    *:"$_install_dir_expr":*)
+        ;;
+    *)
+        # Prepending path in case a system-installed binary needs to be overridden
+        export PATH="$_install_dir_expr:\$PATH"
+        ;;
+esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
+EOF
+}
+
+check_proc() {
+    # Check for /proc by looking for the /proc/self/exe link
+    # This is only run on Linux
+    if ! test -L /proc/self/exe ; then
+        err "fatal: Unable to find /proc/self/exe.  Is /proc mounted?  Installation cannot proceed without /proc."
+    fi
+}
+
+get_bitness() {
+    need_cmd head
+    # Architecture detection without dependencies beyond coreutils.
+    # ELF files start out "\x7fELF", and the following byte is
+    #   0x01 for 32-bit and
+    #   0x02 for 64-bit.
+    # The printf builtin on some shells like dash only supports octal
+    # escape sequences, so we use those.
+    local _current_exe_head
+    _current_exe_head=$(head -c 5 /proc/self/exe )
+    if [ "$_current_exe_head" = "$(printf '\177ELF\001')" ]; then
+        echo 32
+    elif [ "$_current_exe_head" = "$(printf '\177ELF\002')" ]; then
+        echo 64
+    else
+        err "unknown platform bitness"
+    fi
+}
+
+is_host_amd64_elf() {
+    need_cmd head
+    need_cmd tail
+    # ELF e_machine detection without dependencies beyond coreutils.
+    # Two-byte field at offset 0x12 indicates the CPU,
+    # but we're interested in it being 0x3E to indicate amd64, or not that.
+    local _current_exe_machine
+    _current_exe_machine=$(head -c 19 /proc/self/exe | tail -c 1)
+    [ "$_current_exe_machine" = "$(printf '\076')" ]
+}
+
+get_endianness() {
+    local cputype=$1
+    local suffix_eb=$2
+    local suffix_el=$3
+
+    # detect endianness without od/hexdump, like get_bitness() does.
+    need_cmd head
+    need_cmd tail
+
+    local _current_exe_endianness
+    _current_exe_endianness="$(head -c 6 /proc/self/exe | tail -c 1)"
+    if [ "$_current_exe_endianness" = "$(printf '\001')" ]; then
+        echo "${cputype}${suffix_el}"
+    elif [ "$_current_exe_endianness" = "$(printf '\002')" ]; then
+        echo "${cputype}${suffix_eb}"
+    else
+        err "unknown platform endianness"
+    fi
+}
+
+get_architecture() {
+    local _ostype
+    local _cputype
+    _ostype="$(uname -s)"
+    _cputype="$(uname -m)"
+    local _clibtype="gnu"
+    local _local_glibc
+
+    if [ "$_ostype" = Linux ]; then
+        if [ "$(uname -o)" = Android ]; then
+            _ostype=Android
+        fi
+        if ldd --version 2>&1 | grep -q 'musl'; then
+            _clibtype="musl-dynamic"
+        else
+            # Assume all other linuxes are glibc (even if wrong, static libc fallback will apply)
+            _clibtype="gnu"
+        fi
+    fi
+
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ]; then
+        # Darwin `uname -m` lies
+        if sysctl hw.optional.x86_64 | grep -q ': 1'; then
+            _cputype=x86_64
+        fi
+    fi
+
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
+    if [ "$_ostype" = SunOS ]; then
+        # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
+        # so use "uname -o" to disambiguate.  We use the full path to the
+        # system uname in case the user has coreutils uname first in PATH,
+        # which has historically sometimes printed the wrong value here.
+        if [ "$(/usr/bin/uname -o)" = illumos ]; then
+            _ostype=illumos
+        fi
+
+        # illumos systems have multi-arch userlands, and "uname -m" reports the
+        # machine hardware name; e.g., "i86pc" on both 32- and 64-bit x86
+        # systems.  Check for the native (widest) instruction set on the
+        # running kernel:
+        if [ "$_cputype" = i86pc ]; then
+            _cputype="$(isainfo -n)"
+        fi
+    fi
+
+    case "$_ostype" in
+
+        Android)
+            _ostype=linux-android
+            ;;
+
+        Linux)
+            check_proc
+            _ostype=unknown-linux-$_clibtype
+            _bitness=$(get_bitness)
+            ;;
+
+        FreeBSD)
+            _ostype=unknown-freebsd
+            ;;
+
+        NetBSD)
+            _ostype=unknown-netbsd
+            ;;
+
+        DragonFly)
+            _ostype=unknown-dragonfly
+            ;;
+
+        Darwin)
+            _ostype=apple-darwin
+            ;;
+
+        illumos)
+            _ostype=unknown-illumos
+            ;;
+
+        MINGW* | MSYS* | CYGWIN* | Windows_NT)
+            _ostype=pc-windows-gnu
+            ;;
+
+        *)
+            err "unrecognized OS type: $_ostype"
+            ;;
+
+    esac
+
+    case "$_cputype" in
+
+        i386 | i486 | i686 | i786 | x86)
+            _cputype=i686
+            ;;
+
+        xscale | arm)
+            _cputype=arm
+            if [ "$_ostype" = "linux-android" ]; then
+                _ostype=linux-androideabi
+            fi
+            ;;
+
+        armv6l)
+            _cputype=arm
+            if [ "$_ostype" = "linux-android" ]; then
+                _ostype=linux-androideabi
+            else
+                _ostype="${_ostype}eabihf"
+            fi
+            ;;
+
+        armv7l | armv8l)
+            _cputype=armv7
+            if [ "$_ostype" = "linux-android" ]; then
+                _ostype=linux-androideabi
+            else
+                _ostype="${_ostype}eabihf"
+            fi
+            ;;
+
+        aarch64 | arm64)
+            _cputype=aarch64
+            ;;
+
+        x86_64 | x86-64 | x64 | amd64)
+            _cputype=x86_64
+            ;;
+
+        mips)
+            _cputype=$(get_endianness mips '' el)
+            ;;
+
+        mips64)
+            if [ "$_bitness" -eq 64 ]; then
+                # only n64 ABI is supported for now
+                _ostype="${_ostype}abi64"
+                _cputype=$(get_endianness mips64 '' el)
+            fi
+            ;;
+
+        ppc)
+            _cputype=powerpc
+            ;;
+
+        ppc64)
+            _cputype=powerpc64
+            ;;
+
+        ppc64le)
+            _cputype=powerpc64le
+            ;;
+
+        s390x)
+            _cputype=s390x
+            ;;
+        riscv64)
+            _cputype=riscv64gc
+            ;;
+        loongarch64)
+            _cputype=loongarch64
+            ;;
+        *)
+            err "unknown CPU type: $_cputype"
+
+    esac
+
+    # Detect 64-bit linux with 32-bit userland
+    if [ "${_ostype}" = unknown-linux-gnu ] && [ "${_bitness}" -eq 32 ]; then
+        case $_cputype in
+            x86_64)
+                # 32-bit executable for amd64 = x32
+                if is_host_amd64_elf; then {
+                    err "x32 linux unsupported"
+                }; else
+                    _cputype=i686
+                fi
+                ;;
+            mips64)
+                _cputype=$(get_endianness mips '' el)
+                ;;
+            powerpc64)
+                _cputype=powerpc
+                ;;
+            aarch64)
+                _cputype=armv7
+                if [ "$_ostype" = "linux-android" ]; then
+                    _ostype=linux-androideabi
+                else
+                    _ostype="${_ostype}eabihf"
+                fi
+                ;;
+            riscv64gc)
+                err "riscv64 with 32-bit userland unsupported"
+                ;;
+        esac
+    fi
+
+    # treat armv7 systems without neon as plain arm
+    if [ "$_ostype" = "unknown-linux-gnueabihf" ] && [ "$_cputype" = armv7 ]; then
+        if ensure grep '^Features' /proc/cpuinfo | grep -q -v neon; then
+            # At least one processor does not have NEON.
+            _cputype=arm
+        fi
+    fi
+
+    _arch="${_cputype}-${_ostype}"
+
+    RETVAL="$_arch"
+}
+
+say() {
+    if [ "0" = "$PRINT_QUIET" ]; then
+        echo "$1"
+    fi
+}
+
+say_verbose() {
+    if [ "1" = "$PRINT_VERBOSE" ]; then
+        echo "$1"
+    fi
+}
+
+err() {
+    if [ "0" = "$PRINT_QUIET" ]; then
+        local red
+        local reset
+        red=$(tput setaf 1 2>/dev/null || echo '')
+        reset=$(tput sgr0 2>/dev/null || echo '')
+        say "${red}ERROR${reset}: $1" >&2
+    fi
+    exit 1
+}
+
+need_cmd() {
+    if ! check_cmd "$1"
+    then err "need '$1' (command not found)"
+    fi
+}
+
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+    return $?
+}
+
+assert_nz() {
+    if [ -z "$1" ]; then err "assert_nz $2"; fi
+}
+
+# Run a command that should never fail. If the command fails execution
+# will immediately terminate with an error showing the failing
+# command.
+ensure() {
+    if ! "$@"; then err "command failed: $*"; fi
+}
+
+# This is just for indicating that commands' results are being
+# intentionally ignored. Usually, because it's being executed
+# as part of error handling.
+ignore() {
+    "$@"
+}
+
+# This wraps curl or wget. Try curl first, if not installed,
+# use wget instead.
+downloader() {
+    if check_cmd curl
+    then _dld=curl
+    elif check_cmd wget
+    then _dld=wget
+    else _dld='curl or wget' # to be used in error message of need_cmd
+    fi
+
+    if [ "$1" = --check ]
+    then need_cmd "$_dld"
+    elif [ "$_dld" = curl ]
+    then curl -sSfL "$1" -o "$2"
+    elif [ "$_dld" = wget ]
+    then wget "$1" -O "$2"
+    else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
+download_binary_and_run_installer "$@" || exit 1
+
+================ axolotlsay-installer.ps1 ================
+# Licensed under the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+<#
+.SYNOPSIS
+
+The installer for axolotlsay 0.2.2
+
+.DESCRIPTION
+
+This script detects what platform you're on and fetches an appropriate archive from
+https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2
+then unpacks the binaries and installs them to
+
+    $env:CARGO_HOME/bin (or $HOME/.cargo/bin)
+
+It will then add that dir to PATH by editing your Environment.Path registry key
+
+.PARAMETER ArtifactDownloadUrl
+The URL of the directory where artifacts can be fetched from
+
+.PARAMETER NoModifyPath
+Don't add the install directory to PATH
+
+.PARAMETER Help
+Print help
+
+#>
+
+param (
+    [Parameter(HelpMessage = "The URL of the directory where artifacts can be fetched from")]
+    [string]$ArtifactDownloadUrl = 'https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2',
+    [Parameter(HelpMessage = "Don't add the install directory to PATH")]
+    [switch]$NoModifyPath,
+    [Parameter(HelpMessage = "Print Help")]
+    [switch]$Help
+)
+
+$app_name = 'axolotlsay'
+$app_version = '0.2.2'
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
+
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+if ($env:XDG_CONFIG_HOME) {
+  $receipt_home = "${env:XDG_CONFIG_HOME}\axolotlsay"
+} else {
+  $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+}
+
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
+function Install-Binary($install_args) {
+  if ($Help) {
+    Get-Help $PSCommandPath -Detailed
+    Exit
+  }
+
+  Initialize-Environment
+
+  # Platform info injected by dist
+  $platforms = @{
+    "aarch64-pc-windows-msvc" = @{
+      "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
+      "staticlibs" = @()
+      "zip_ext" = ".tar.gz"
+      "aliases" = @{
+      }
+      "aliases_json" = '{}'
+    }
+    "x86_64-pc-windows-gnu" = @{
+      "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
+      "staticlibs" = @()
+      "zip_ext" = ".tar.gz"
+      "aliases" = @{
+      }
+      "aliases_json" = '{}'
+    }
+    "x86_64-pc-windows-msvc" = @{
+      "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
+      "staticlibs" = @()
+      "zip_ext" = ".tar.gz"
+      "aliases" = @{
+      }
+      "aliases_json" = '{}'
+    }
+  }
+
+  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  # FIXME: add a flag that lets the user not do this step
+  try {
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
+}
+
+function Get-TargetTriple($platforms) {
+  $double = Get-Arch
+  if ($platforms.Contains("$double-msvc")) {
+    return "$double-msvc"
+  } else {
+    return "$double-gnu"
+  }
+}
+
+function Get-Arch() {
+  try {
+    # NOTE: this might return X64 on ARM64 Windows, which is OK since emulation is available.
+    # It works correctly starting in PowerShell Core 7.3 and Windows PowerShell in Win 11 22H2.
+    # Ideally this would just be
+    #   [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    # but that gets a type from the wrong assembly on Windows PowerShell (i.e. not Core)
+    $a = [System.Reflection.Assembly]::LoadWithPartialName("System.Runtime.InteropServices.RuntimeInformation")
+    $t = $a.GetType("System.Runtime.InteropServices.RuntimeInformation")
+    $p = $t.GetProperty("OSArchitecture")
+    # Possible OSArchitecture Values: https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.architecture
+    # Rust supported platforms: https://doc.rust-lang.org/stable/rustc/platform-support.html
+    switch ($p.GetValue($null).ToString())
+    {
+      "X86" { return "i686-pc-windows" }
+      "X64" { return "x86_64-pc-windows" }
+      "Arm" { return "thumbv7a-pc-windows" }
+      "Arm64" { return "aarch64-pc-windows" }
+    }
+  } catch {
+    # The above was added in .NET 4.7.1, so Windows PowerShell in versions of Windows
+    # prior to Windows 10 v1709 may not have this API.
+    Write-Verbose "Get-TargetTriple: Exception when trying to determine OS architecture."
+    Write-Verbose $_
+  }
+
+  # This is available in .NET 4.0. We already checked for PS 5, which requires .NET 4.5.
+  Write-Verbose("Get-TargetTriple: falling back to Is64BitOperatingSystem.")
+  if ([System.Environment]::Is64BitOperatingSystem) {
+    return "x86_64-pc-windows"
+  } else {
+    return "i686-pc-windows"
+  }
+}
+
+function Download($download_url, $platforms) {
+  $arch = Get-TargetTriple $platforms
+
+  if (-not $platforms.ContainsKey($arch)) {
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
+  # Lookup what we expect this platform to look like
+  $info = $platforms[$arch]
+  $zip_ext = $info["zip_ext"]
+  $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
+  $artifact_name = $info["artifact_name"]
+
+  # Make a new temp dir to unpack things to
+  $tmp = New-Temp-Dir
+  $dir_path = "$tmp\$app_name$zip_ext"
+
+  # Download and unpack!
+  $url = "$download_url/$artifact_name"
+  Write-Information "Downloading $app_name $app_version ($arch)"
+  Write-Verbose "  from $url"
+  Write-Verbose "  to $dir_path"
+  $wc = New-Object Net.Webclient
+  $wc.downloadFile($url, $dir_path)
+
+  Write-Verbose "Unpacking to $tmp"
+
+  # Select the tool to unpack the files with.
+  #
+  # As of windows 10(?), powershell comes with tar preinstalled, but in practice
+  # it only seems to support .tar.gz, and not xz/zstd. Still, we should try to
+  # forward all tars to it in case the user has a machine that can handle it!
+  switch -Wildcard ($zip_ext) {
+    ".zip" {
+      Expand-Archive -Path $dir_path -DestinationPath "$tmp";
+      Break
+    }
+    ".tar.*" {
+      tar xf $dir_path --strip-components 1 -C "$tmp";
+      Break
+    }
+    Default {
+      throw "ERROR: unknown archive format $zip_ext"
+    }
+  }
+
+  # Let the next step know what to copy
+  $bin_paths = @()
+  foreach ($bin_name in $bin_names) {
+    Write-Verbose "  Unpacked $bin_name"
+    $bin_paths += "$tmp\$bin_name"
+  }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
+
+  if (($null -ne $info["updater"]) -and $install_updater) {
+    $updater_id = $info["updater"]["artifact_name"]
+    $updater_url = "$download_url/$updater_id"
+    $out_name = "$tmp\axolotlsay-update.exe"
+
+    $wc.downloadFile($updater_url, $out_name)
+    $bin_paths += $out_name
+  }
+
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
+  }
+}
+
+function Invoke-Installer($artifacts, $platforms) {
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple $platforms
+
+  if (-not $platforms.ContainsKey($arch)) {
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
+  $info = $platforms[$arch]
+
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = $null
+  $install_layout = "unspecified"
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $install_layout = "cargo-home"
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $install_layout = "cargo-home"
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $install_layout = "flat"
+  }
+
+  # Check if the install layout should be changed from `flat` to `cargo-home`
+  # for backwards compatible updates of applications that switched layouts.
+  if (($force_install_dir) -and ($install_layout -eq "flat")) {
+    # If the install directory is targeting the Cargo home directory, then
+    # we assume this application was previously installed that layout
+    # Note the installer passes the path with `\\` separators, but here they are
+    # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
+    # may not exist.
+    $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
+    }
+    if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
+      $install_layout = "cargo-home"
+    }
+  }
+
+  # The actual path we're going to install to
+  $dest_dir = $null
+  $dest_dir_lib = $null
+  # The install prefix we write to the receipt.
+  # For organized install methods like CargoHome, which have
+  # subdirectories, this is the root without `/bin`. For other
+  # methods, this is the same as `_install_dir`.
+  $receipt_dest_dir = $null
+  # Before actually consulting the configured install strategy, see
+  # if we're overriding it.
+  if (($force_install_dir)) {
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
+    }
+    $receipt_dest_dir = $force_install_dir
+  }
+  if (-Not $dest_dir) {
+    # first try $env:CARGO_HOME, then fallback to $HOME
+    # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
+    $root = if (($base_dir = $env:CARGO_HOME)) {
+      $base_dir
+    } elseif (($base_dir = $HOME)) {
+      Join-Path $base_dir ".cargo"
+    } else {
+      throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
+    }
+
+    $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
+    $receipt_dest_dir = $root
+    $install_layout = "cargo-home"
+  }
+
+  # Looks like all of the above assignments failed
+  if (-Not $dest_dir) {
+    throw "ERROR: could not find a valid path to install to; please check the installation instructions"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
+
+  $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
+  Write-Information "Installing to $dest_dir"
+  # Just copy the binaries from the temp location to the install dir
+  foreach ($bin_path in $artifacts["bin_paths"]) {
+    $installed_file = Split-Path -Path "$bin_path" -Leaf
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+
+    if (($dests = $info["aliases"][$installed_file])) {
+      $source = Join-Path "$dest_dir" "$installed_file"
+      foreach ($dest_name in $dests) {
+          $dest = Join-Path $dest_dir $dest_name
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
+      }
+    }
+  }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
+
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
+  # Also replace the aliases with the arch-specific one
+  $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
+  if ($NoModifyPath) {
+    $receipt = $receipt.Replace('"modify_path":true', '"modify_path":false')
+  }
+
+  # Write the install receipt
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
+
+  # Respect the environment, but CLI takes precedence
+  if ($null -eq $NoModifyPath) {
+    $NoModifyPath = $env:INSTALLER_NO_MODIFY_PATH
+  }
+
+  Write-Information "everything's installed!"
+  if (-not $NoModifyPath) {
+    Add-Ci-Path $dest_dir
+    if (Add-Path $dest_dir) {
+        Write-Information ""
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
+        Write-Information ""
+        Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
+        Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
+    }
+  }
+}
+
+# Attempt to do CI-specific rituals to get the install-dir on PATH faster
+function Add-Ci-Path($OrigPathToAdd) {
+  # If GITHUB_PATH is present, then write install_dir to the file it refs.
+  # After each GitHub Action, the contents will be added to PATH.
+  # So if you put a curl | sh for this script in its own "run" step,
+  # the next step will have this dir on PATH.
+  #
+  # Note that GITHUB_PATH will not resolve any variables, so we in fact
+  # want to write the install dir and not an expression that evals to it
+  if (($gh_path = $env:GITHUB_PATH)) {
+    Write-Output "$OrigPathToAdd" | Out-File -FilePath "$gh_path" -Encoding utf8 -Append
+  }
+}
+
+# Try to permanently add the given path to the user-level
+# PATH via the registry
+#
+# Returns true if the registry was modified, otherwise returns false
+# (indicating it was already on PATH)
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
+
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
+
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
+
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
+    return $false
+  }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
+}
+
+function Initialize-Environment() {
+  If (($PSVersionTable.PSVersion.Major) -lt 5) {
+    throw @"
+Error: PowerShell 5 or later is required to install $app_name.
+Upgrade PowerShell:
+
+    https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell
+
+"@
+  }
+
+  # show notification to change execution policy:
+  $allowedExecutionPolicy = @('Unrestricted', 'RemoteSigned', 'Bypass')
+  If ((Get-ExecutionPolicy).ToString() -notin $allowedExecutionPolicy) {
+    throw @"
+Error: PowerShell requires an execution policy in [$($allowedExecutionPolicy -join ", ")] to run $app_name. For example, to set the execution policy to 'RemoteSigned' please run:
+
+    Set-ExecutionPolicy RemoteSigned -scope CurrentUser
+
+"@
+  }
+
+  # GitHub requires TLS 1.2
+  If ([System.Enum]::GetNames([System.Net.SecurityProtocolType]) -notcontains 'Tls12') {
+    throw @"
+Error: Installing $app_name requires at least .NET Framework 4.5
+Please download and install it first:
+
+    https://www.microsoft.com/net/download
+
+"@
+  }
+}
+
+function New-Temp-Dir() {
+  [CmdletBinding(SupportsShouldProcess)]
+  param()
+  $parent = [System.IO.Path]::GetTempPath()
+  [string] $name = [System.Guid]::NewGuid()
+  New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+# PSScriptAnalyzer doesn't like how we use our params as globals, this calms it
+$Null = $ArtifactDownloadUrl, $NoModifyPath, $Help
+# Make Write-Information statements be visible
+$InformationPreference = "Continue"
+
+# The default interactive handler
+try {
+  Install-Binary "$Args"
+} catch {
+  Write-Information $_
+  exit 1
+}
+
+================ sha256.sum ================
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
+
+================ dist-manifest.json ================
+{
+  "dist_version": "CENSORED",
+  "announcement_tag": "v0.2.2",
+  "announcement_tag_is_implicit": true,
+  "announcement_is_prerelease": false,
+  "announcement_title": "Version 0.2.2",
+  "announcement_changelog": "```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
+  "announcement_github_body": "## Release Notes\n\n```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Install axolotlsay 0.2.2\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\npowershell -ExecutionPolicy Bypass -c \"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.ps1 | iex\"\n```\n\n## Download axolotlsay 0.2.2\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-aarch64-apple-darwin.pkg](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.pkg) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.pkg.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.pkg](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.pkg) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.pkg.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.msi](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.msi) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.msi.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256) |\n\n",
+  "releases": [
+    {
+      "app_name": "axolotlsay",
+      "app_version": "0.2.2",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+      },
+      "display_name": "axolotlsay",
+      "display": true,
+      "artifacts": [
+        "source.tar.gz",
+        "source.tar.gz.sha256",
+        "axolotlsay-installer.sh",
+        "axolotlsay-installer.ps1",
+        "sha256.sum",
+        "axolotlsay-aarch64-apple-darwin.tar.gz",
+        "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
+        "axolotlsay-aarch64-apple-darwin.pkg",
+        "axolotlsay-aarch64-apple-darwin.pkg.sha256",
+        "axolotlsay-x86_64-apple-darwin.tar.gz",
+        "axolotlsay-x86_64-apple-darwin.tar.gz.sha256",
+        "axolotlsay-x86_64-apple-darwin.pkg",
+        "axolotlsay-x86_64-apple-darwin.pkg.sha256",
+        "axolotlsay-x86_64-pc-windows-msvc.tar.gz",
+        "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256",
+        "axolotlsay-x86_64-pc-windows-msvc.msi",
+        "axolotlsay-x86_64-pc-windows-msvc.msi.sha256",
+        "axolotlsay-x86_64-unknown-linux-gnu.tar.gz",
+        "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256"
+      ],
+      "hosting": {
+        "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
+          "owner": "axodotdev",
+          "repo": "axolotlsay"
+        }
+      }
+    }
+  ],
+  "artifacts": {
+    "axolotlsay-aarch64-apple-darwin.pkg": {
+      "name": "axolotlsay-aarch64-apple-darwin.pkg",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ],
+      "assets": [
+        {
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay",
+          "kind": "executable"
+        }
+      ],
+      "description": "install via pkg",
+      "checksum": "axolotlsay-aarch64-apple-darwin.pkg.sha256"
+    },
+    "axolotlsay-aarch64-apple-darwin.pkg.sha256": {
+      "name": "axolotlsay-aarch64-apple-darwin.pkg.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ]
+    },
+    "axolotlsay-aarch64-apple-darwin.tar.gz": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.gz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-aarch64-apple-darwin.tar.gz.sha256"
+    },
+    "axolotlsay-aarch64-apple-darwin.tar.gz.sha256": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ]
+    },
+    "axolotlsay-installer.ps1": {
+      "name": "axolotlsay-installer.ps1",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-pc-windows-msvc",
+        "x86_64-pc-windows-gnu",
+        "x86_64-pc-windows-msvc"
+      ],
+      "install_hint": "powershell -ExecutionPolicy Bypass -c \"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.ps1 | iex\"",
+      "description": "Install prebuilt binaries via powershell script"
+    },
+    "axolotlsay-installer.sh": {
+      "name": "axolotlsay-installer.sh",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-pc-windows-gnu",
+        "x86_64-unknown-linux-gnu"
+      ],
+      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh",
+      "description": "Install prebuilt binaries via shell script"
+    },
+    "axolotlsay-x86_64-apple-darwin.pkg": {
+      "name": "axolotlsay-x86_64-apple-darwin.pkg",
+      "kind": "installer",
+      "target_triples": [
+        "x86_64-apple-darwin"
+      ],
+      "assets": [
+        {
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay",
+          "kind": "executable"
+        }
+      ],
+      "description": "install via pkg",
+      "checksum": "axolotlsay-x86_64-apple-darwin.pkg.sha256"
+    },
+    "axolotlsay-x86_64-apple-darwin.pkg.sha256": {
+      "name": "axolotlsay-x86_64-apple-darwin.pkg.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-apple-darwin"
+      ]
+    },
+    "axolotlsay-x86_64-apple-darwin.tar.gz": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.gz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-apple-darwin"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-apple-darwin.tar.gz.sha256"
+    },
+    "axolotlsay-x86_64-apple-darwin.tar.gz.sha256": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.gz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-apple-darwin"
+      ]
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.msi": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.msi",
+      "kind": "installer",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay.exe",
+          "kind": "executable"
+        }
+      ],
+      "description": "install via msi",
+      "checksum": "axolotlsay-x86_64-pc-windows-msvc.msi.sha256"
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.msi.sha256": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.msi.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ]
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.tar.gz": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.tar.gz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay.exe",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256"
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ]
+    },
+    "axolotlsay-x86_64-unknown-linux-gnu.tar.gz": {
+      "name": "axolotlsay-x86_64-unknown-linux-gnu.tar.gz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-unknown-linux-gnu"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256"
+    },
+    "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256": {
+      "name": "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-unknown-linux-gnu"
+      ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
+    }
+  },
+  "systems": {
+    "plan:all:": {
+      "id": "plan:all:",
+      "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
+    }
+  },
+  "publish_prereleases": false,
+  "force_latest": false,
+  "ci": {
+    "github": {
+      "artifacts_matrix": {
+        "include": [
+          {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oxidecomputer/cargo-dist/releases/download/vSOME_VERSION/dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
+            "cache_provider": "github"
+          },
+          {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oxidecomputer/cargo-dist/releases/download/vSOME_VERSION/dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
+            "cache_provider": "github"
+          },
+          {
+            "runner": "windows-2022",
+            "host": "x86_64-pc-windows-msvc",
+            "install_dist": {
+              "shell": "pwsh",
+              "run": "irm https://github.com/oxidecomputer/cargo-dist/releases/download/vSOME_VERSION/dist-installer.ps1 | iex"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
+            "cache_provider": "github"
+          },
+          {
+            "runner": "ubuntu-22.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oxidecomputer/cargo-dist/releases/download/vSOME_VERSION/dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
+            "cache_provider": "github"
+          }
+        ]
+      },
+      "pr_run_mode": "plan"
+    }
+  },
+  "linkage": [],
+  "upload_files": []
+}
+
+================ release.yml ================
+# This file was autogenerated by dist: https://opensource.axo.dev/cargo-dist/
+#
+# Copyright 2022-2024, axodotdev
+# Copyright 2025, Oxide Computer Company
+# SPDX-License-Identifier: MIT or Apache-2.0
+#
+# CI that:
+#
+# * checks for a Git Tag that looks like a release
+# * builds artifacts with dist (archives, installers, hashes)
+# * uploads those artifacts to temporary workflow zip
+# * on success, uploads the artifacts to a GitHub Release
+#
+# Note that the GitHub Release will be created with a generated
+# title/body based on your changelogs.
+
+name: Release
+permissions:
+  "contents": "write"
+
+# This task will run whenever you push a git tag that looks like a version
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
+# PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
+#
+# If PACKAGE_NAME is specified, then the announcement will be for that
+# package (erroring out if it doesn't have the given version or isn't dist-able).
+#
+# If PACKAGE_NAME isn't specified, then the announcement will be for all
+# (dist-able) packages in the workspace with that version (this mode is
+# intended for workspaces with only one dist-able package, or with all dist-able
+# packages versioned/released in lockstep).
+#
+# If you push multiple tags at once, separate instances of this workflow will
+# spin up, creating an independent announcement for each one. However, GitHub
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
+#
+# If there's a prerelease-style suffix to the version, then the release(s)
+# will be marked as a prerelease.
+on:
+  pull_request:
+  push:
+    tags:
+      - '**[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  # Run 'dist plan' (or host) to determine what tasks we need to do
+  plan:
+    runs-on: "ubuntu-22.04"
+    outputs:
+      val: ${{ steps.plan.outputs.manifest }}
+      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
+      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
+      publishing: ${{ !github.event.pull_request }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dist
+        # we specify bash to get pipefail; it guards against the `curl` command
+        # failing. otherwise `sh` won't catch that `curl` returned non-0
+        shell: bash
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oxidecomputer/cargo-dist/releases/download/vSOME_VERSION/dist-installer.sh | sh"
+      - name: Cache dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/dist
+      # sure would be cool if github gave us proper conditionals...
+      # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
+      # functionality based on whether this is a pull_request, and whether it's from a fork.
+      # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
+      # but also really annoying to build CI around when it needs secrets to work right.)
+      - id: plan
+        run: |
+          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          echo "dist ran successfully"
+          cat plan-dist-manifest.json
+          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: "Upload dist-manifest.json"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-plan-dist-manifest
+          path: plan-dist-manifest.json
+
+  # Build and packages all the platform-specific things
+  build-local-artifacts:
+    name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
+    # Let the initial task tell us to not run (currently very blunt)
+    needs:
+      - plan
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    strategy:
+      fail-fast: false
+      # Target platforms/runners are computed by dist in create-release.
+      # Each member of the matrix has the following arguments:
+      #
+      # - runner: the github runner
+      # - dist-args: cli flags to pass to dist
+      # - install-dist: expression to run to install dist on the runner
+      #
+      # Typically there will be:
+      # - 1 "global" task that builds universal installers
+      # - N "local" tasks that build each platform's binaries and platform-specific installers
+      matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      CODESIGN_CERTIFICATE: ${{ secrets.CODESIGN_CERTIFICATE }}
+      CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+      CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+    steps:
+      - name: enable windows longpaths
+        run: |
+          git config --global core.longpaths true
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
+      - name: Install dist
+        run: ${{ matrix.install_dist.run }}
+      # Get the dist-manifest
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - name: Install dependencies
+        run: |
+          ${{ matrix.packages_install }}
+      - name: Build artifacts
+        run: |
+          # Actually do builds and make zips and whatnot
+          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          echo "dist ran successfully"
+      - id: cargo-dist
+        name: Post-build
+        # We force bash here just because github makes it really hard to get values up
+        # to "real" actions without writing to env-vars, and writing to env-vars has
+        # inconsistent syntax between shell and powershell.
+        shell: bash
+        run: |
+          # Parse out what we just built and upload it to scratch storage
+          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-build-local-${{ join(matrix.targets, '_') }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+
+  # Build and package all the platform-agnostic(ish) things
+  build-global-artifacts:
+    needs:
+      - plan
+      - build-local-artifacts
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install cached dist
+        uses: actions/download-artifact@v4
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/
+      - run: chmod +x ~/.cargo/bin/dist
+      # Get all the local artifacts for the global tasks to use (for e.g. checksums)
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - id: cargo-dist
+        shell: bash
+        run: |
+          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
+          echo "dist ran successfully"
+
+          # Parse out what we just built and upload it to scratch storage
+          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-build-global
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+  # Determines if we should publish/announce
+  host:
+    needs:
+      - plan
+      - build-local-artifacts
+      - build-global-artifacts
+    # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: "ubuntu-22.04"
+    outputs:
+      val: ${{ steps.host.outputs.manifest }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install cached dist
+        uses: actions/download-artifact@v4
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/
+      - run: chmod +x ~/.cargo/bin/dist
+      # Fetch artifacts from scratch-storage
+      - name: Fetch artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - id: host
+        shell: bash
+        run: |
+          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          echo "artifacts uploaded and released successfully"
+          cat dist-manifest.json
+          echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: "Upload dist-manifest.json"
+        uses: actions/upload-artifact@v4
+        with:
+          # Overwrite the previous copy
+          name: artifacts-dist-manifest
+          path: dist-manifest.json
+      # Create a GitHub Release while uploading all files to it
+      - name: "Download GitHub Artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: artifacts
+          merge-multiple: true
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm -f artifacts/*-dist-manifest.json
+      - name: Create GitHub Release
+        env:
+          PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
+          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
+          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
+          RELEASE_COMMIT: "${{ github.sha }}"
+        run: |
+          # Write and read notes from a file to avoid quoting breaking things
+          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+
+          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+
+  announce:
+    needs:
+      - plan
+      - host
+    # use "always() && ..." to allow us to wait for all publish jobs while
+    # still allowing individual publish jobs to skip themselves (for prereleases).
+    # "host" however must run to completion, no skipping allowed!
+    if: ${{ always() && needs.host.result == 'success' }}
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+================ main.wxs ================
+<?xml version='1.0' encoding='windows-1252'?>
+<!--
+  Copyright (C) 2017 Christopher R. Field.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+  The "cargo wix" subcommand provides a variety of predefined variables available
+  for customization of this template. The values for each variable are set at
+  installer creation time. The following variables are available:
+
+  TargetTriple      = The rustc target triple name.
+  TargetEnv         = The rustc target environment. This is typically either
+                      "msvc" or "gnu" depending on the toolchain downloaded and
+                      installed.
+  TargetVendor      = The rustc target vendor. This is typically "pc", but Rust
+                      does support other vendors, like "uwp".
+  CargoTargetBinDir = The complete path to the directory containing the
+                      binaries (exes) to include. The default would be
+                      "target\release\". If an explicit rustc target triple is
+                      used, i.e. cross-compiling, then the default path would
+                      be "target\<CARGO_TARGET>\<CARGO_PROFILE>",
+                      where "<CARGO_TARGET>" is replaced with the "CargoTarget"
+                      variable value and "<CARGO_PROFILE>" is replaced with the
+                      value from the "CargoProfile" variable. This can also
+                      be overridden manually with the "target-bin-dir" flag.
+  CargoTargetDir    = The path to the directory for the build artifacts, i.e.
+                      "target".
+  CargoProfile      = The cargo profile used to build the binaries
+                      (usually "debug" or "release").
+  Version           = The version for the installer. The default is the
+                      "Major.Minor.Fix" semantic versioning number of the Rust
+                      package.
+-->
+
+<!--
+  Please do not remove these pre-processor If-Else blocks. These are used with
+  the `cargo wix` subcommand to automatically determine the installation
+  destination for 32-bit versus 64-bit installers. Removal of these lines will
+  cause installation errors.
+-->
+<?if $(sys.BUILDARCH) = x64 or $(sys.BUILDARCH) = arm64 ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?else ?>
+    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+<?endif ?>
+
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+
+    <Product
+        Id='*'
+        Name='axolotlsay'
+        UpgradeCode='B36177BE-EA4D-44FB-B05C-EDDABDAA95CA'
+        Manufacturer='axodotdev'
+        Language='1033'
+        Codepage='1252'
+        Version='$(var.Version)'>
+
+        <Package Id='*'
+            Keywords='Installer'
+            Description='💬 a CLI for learning to distribute CLIs in rust'
+            Manufacturer='axodotdev'
+            InstallerVersion='450'
+            Languages='1033'
+            Compressed='yes'
+            InstallScope='perMachine'
+            SummaryCodepage='1252'
+            />
+
+        <MajorUpgrade
+            Schedule='afterInstallInitialize'
+            DowngradeErrorMessage='A newer version of [ProductName] is already installed. Setup will now exit.'/>
+
+        <Media Id='1' Cabinet='media1.cab' EmbedCab='yes' DiskPrompt='CD-ROM #1'/>
+        <Property Id='DiskPrompt' Value='axolotlsay Installation'/>
+
+        <Directory Id='TARGETDIR' Name='SourceDir'>
+            <Directory Id='$(var.PlatformProgramFilesFolder)' Name='PFiles'>
+                <Directory Id='APPLICATIONFOLDER' Name='axolotlsay'>
+                    
+                    <!--
+                      Enabling the license sidecar file in the installer is a four step process:
+
+                      1. Uncomment the `Component` tag and its contents.
+                      2. Change the value for the `Source` attribute in the `File` tag to a path
+                         to the file that should be included as the license sidecar file. The path
+                         can, and probably should be, relative to this file.
+                      3. Change the value for the `Name` attribute in the `File` tag to the
+                         desired name for the file when it is installed alongside the `bin` folder
+                         in the installation directory. This can be omitted if the desired name is
+                         the same as the file name.
+                      4. Uncomment the `ComponentRef` tag with the Id attribute value of "License"
+                         further down in this file.
+                    -->
+                    <!--
+                    <Component Id='License' Guid='*'>
+                        <File Id='LicenseFile' Name='ChangeMe' DiskId='1' Source='C:\Path\To\File' KeyPath='yes'/>
+                    </Component>
+                    -->
+
+                    <Directory Id='Bin' Name='bin'>
+                        <Component Id='Path' Guid='BFD25009-65A4-4D1E-97F1-0030465D90D6' KeyPath='yes'>
+                            <Environment
+                                Id='PATH'
+                                Name='PATH'
+                                Value='[Bin]'
+                                Permanent='no'
+                                Part='last'
+                                Action='set'
+                                System='yes'/>
+                        </Component>
+                        <Component Id='binary0' Guid='*'>
+                            <File
+                                Id='exe0'
+                                Name='axolotlsay.exe'
+                                DiskId='1'
+                                Source='$(var.CargoTargetBinDir)\axolotlsay.exe'
+                                KeyPath='yes'/>
+                        </Component>
+                    </Directory>
+                </Directory>
+            </Directory>
+        </Directory>
+
+        <Feature
+            Id='Binaries'
+            Title='Application'
+            Description='Installs all binaries and the license.'
+            Level='1'
+            ConfigurableDirectory='APPLICATIONFOLDER'
+            AllowAdvertise='no'
+            Display='expand'
+            Absent='disallow'>
+            
+            <!--
+              Uncomment the following `ComponentRef` tag to add the license
+              sidecar file to the installer.
+            -->
+            <!--<ComponentRef Id='License'/>-->
+
+            <ComponentRef Id='binary0'/>
+
+            <Feature
+                Id='Environment'
+                Title='PATH Environment Variable'
+                Description='Add the install location of the [ProductName] executable to the PATH system environment variable. This allows the [ProductName] executable to be called from any location.'
+                Level='1'
+                Absent='allow'>
+                <ComponentRef Id='Path'/>
+            </Feature>
+        </Feature>
+
+        <SetProperty Id='ARPINSTALLLOCATION' Value='[APPLICATIONFOLDER]' After='CostFinalize'/>
+
+        
+        <!--
+          Uncomment the following `Icon` and `Property` tags to change the product icon.
+
+          The product icon is the graphic that appears in the Add/Remove
+          Programs control panel for the application.
+        -->
+        <!--<Icon Id='ProductICO' SourceFile='wix\Product.ico'/>-->
+        <!--<Property Id='ARPPRODUCTICON' Value='ProductICO' />-->
+
+        <Property Id='ARPHELPLINK' Value='https://github.com/axodotdev/axolotlsay'/>
+        
+        <UI>
+            <UIRef Id='WixUI_FeatureTree'/>
+            
+            <!--
+              Enabling the EULA dialog in the installer is a three step process:
+
+                1. Comment out or remove the two `Publish` tags that follow the
+                   `WixVariable` tag.
+                2. Uncomment the `<WixVariable Id='WixUILicenseRtf' Value='Path\to\Eula.rft'>` tag further down
+                3. Replace the `Value` attribute of the `WixVariable` tag with
+                   the path to a RTF file that will be used as the EULA and
+                   displayed in the license agreement dialog.
+            -->
+            <Publish Dialog='WelcomeDlg' Control='Next' Event='NewDialog' Value='CustomizeDlg' Order='99'>1</Publish>
+            <Publish Dialog='CustomizeDlg' Control='Back' Event='NewDialog' Value='WelcomeDlg' Order='99'>1</Publish>
+
+        </UI>
+
+        
+        <!--
+          Enabling the EULA dialog in the installer requires uncommenting
+          the following `WixUILicenseRTF` tag and changing the `Value`
+          attribute.
+        -->
+        <!-- <WixVariable Id='WixUILicenseRtf' Value='Relative\Path\to\Eula.rtf'/> -->
+
+        
+        <!--
+          Uncomment the next `WixVariable` tag to customize the installer's
+          Graphical User Interface (GUI) and add a custom banner image across
+          the top of each screen. See the WiX Toolset documentation for details
+          about customization.
+
+          The banner BMP dimensions are 493 x 58 pixels.
+        -->
+        <!--<WixVariable Id='WixUIBannerBmp' Value='wix\Banner.bmp'/>-->
+
+        
+        <!--
+          Uncomment the next `WixVariable` tag to customize the installer's
+          Graphical User Interface (GUI) and add a custom image to the first
+          dialog, or screen. See the WiX Toolset documentation for details about
+          customization.
+
+          The dialog BMP dimensions are 493 x 312 pixels.
+        -->
+        <!--<WixVariable Id='WixUIDialogBmp' Value='wix\Dialog.bmp'/>-->
+
+    </Product>
+
+</Wix>


### PR DESCRIPTION
The workspace-level `macos-sign` TOML config option was not being properly inherited by the workspace config. This was due to the build layer being left as `None` despite codesigning being enabled.

Include `macos_sign` in the list of options that require a build layer to be set.