### PR TITLE
Enable codesigning for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oxidecomputer/cargo-dist/releases/download/v1.0.6/dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oxidecomputer/cargo-dist/releases/download/v1.0.7/dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -114,6 +114,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      SSLDOTCOM_USERNAME: ${{ secrets.SSLDOTCOM_USERNAME }}
+      SSLDOTCOM_PASSWORD: ${{ secrets.SSLDOTCOM_PASSWORD }}
+      SSLDOTCOM_CREDENTIAL_ID: ${{ secrets.SSLDOTCOM_CREDENTIAL_ID }}
+      SSLDOTCOM_TOTP_SECRET: ${{ secrets.SSLDOTCOM_TOTP_SECRET }}
       CODESIGN_CERTIFICATE: ${{ secrets.CODESIGN_CERTIFICATE }}
       CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
       CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Nothing Yet!
 
+# Version 1.0.8 (2025-07-11)
+
+- Codesign Windows binaries.
+
 # Version 1.0.7 (2025-07-04)
 
 - Fix long lines in Homebrew formula.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "axoasset",
  "axoprocess",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "dist"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "axoasset",
  "axocli",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "dist-schema"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "camino",
  "gazenot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidecomputer/cargo-dist"
 homepage = "https://opensource.axo.dev/cargo-dist/"
-version = "1.0.7"
+version = "1.0.8"
 rust-version = "1.88"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
-dist-schema = { version = "=1.0.7", path = "cargo-dist-schema" }
-axoproject = { version = "=1.0.7", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
+dist-schema = { version = "=1.0.8", path = "cargo-dist-schema" }
+axoproject = { version = "=1.0.8", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # vendored first-party deps
 axocli = { version = "0.2.0", path = "vendor/axocli" }

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "1.0.6"
+cargo-dist-version = "1.0.7"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -23,6 +23,8 @@ github-attestations = true
 install-path = "CARGO_HOME"
 # Whether to sign macOS executables
 macos-sign = true
+# Whether to sign Windows executables
+ssldotcom-windows-sign = "prod"
 # A GitHub repo to push Homebrew formulas to
 tap = "oxidecomputer/homebrew-tap"
 # Publish jobs to run in CI


### PR DESCRIPTION
Start codesigning our Windows binaries. While we're at it, build with v1.0.7.