### PR TITLE
Limit permissions of token in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 # The "Normal" CI for tests and linters and whatnot
 name: Rust CI
+permissions:
+  contents: read
 
 # Ci should be run on...
 on:


### PR DESCRIPTION
Appease the security alert by limiting the `GITHUB_TOKEN` to read-only permissions in the `ci` workflow.