### PR TITLE
Allow checks to be written in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 name: Rust CI
 permissions:
   contents: read
+  checks: write
 
 # Ci should be run on...
 on:


### PR DESCRIPTION
The clippy action needs permission to write checks. Grant it.